### PR TITLE
Add resolveFrom option

### DIFF
--- a/plugins/include-markdown/README.md
+++ b/plugins/include-markdown/README.md
@@ -31,6 +31,16 @@ Disclaimer: This content is not guaranteed to be in any way useful or truthful.
 <p>The rest of the content...</p>
 ```
 
+### Options
+
+This plugin accepts one optional config option: `resolveFrom`. If you pass this option along with a path, all partials will resolve from the path that was passed in. For example:
+
+```js
+remark().use(includeMarkdown, { resolveFrom: path.join(__dirname, 'partials') })
+```
+
+With this config, you'd be able to put all your includes in a partials folder and require only based on the filename regardless of the location of your markdown file.
+
 ### Ordering
 
 It's important to note that remark applies transforms in the order that they are called. If you want your other plugins to also apply to the contents of includeed files, you need to make sure that you apply the include content plugin **before all other plugins**. For example, let's say you have two plugins, one is this one to include markdown, and the other capitalizes all text, because yelling makes you more authoritative and also it's easier to read capitalized text. If you want to ensure that your includeed content is also capitalized, here's how you'd order your plugins:

--- a/plugins/include-markdown/fixtures/resolve-from.expected.md
+++ b/plugins/include-markdown/fixtures/resolve-from.expected.md
@@ -1,0 +1,1 @@
+I come from a nested folder

--- a/plugins/include-markdown/fixtures/resolve-from.md
+++ b/plugins/include-markdown/fixtures/resolve-from.md
@@ -1,0 +1,1 @@
+@include 'include2.md'

--- a/plugins/include-markdown/index.js
+++ b/plugins/include-markdown/index.js
@@ -3,7 +3,7 @@ const remark = require('remark')
 const flatMap = require('unist-util-flatmap')
 const { readSync } = require('to-vfile')
 
-module.exports = function includeMarkdownPlugin() {
+module.exports = function includeMarkdownPlugin({ resolveFrom } = {}) {
   return function transformer(tree, file) {
     return flatMap(tree, node => {
       if (node.type !== 'paragraph') return [node]
@@ -15,7 +15,10 @@ module.exports = function includeMarkdownPlugin() {
       if (!includeMatch) return [node]
 
       // read the file contents
-      const includePath = path.join(file.dirname, includeMatch[1])
+      const includePath = path.join(
+        resolveFrom || file.dirname,
+        includeMatch[1]
+      )
       let includeContents
       try {
         includeContents = readSync(includePath)

--- a/plugins/include-markdown/index.test.js
+++ b/plugins/include-markdown/index.test.js
@@ -25,6 +25,19 @@ describe('include-markdown', () => {
       /The @include file path at .*fixtures\/bskjbfkhj was not found.\n\nInclude Location: .*fixtures\/invalid-path\.md:3:1/gm
     )
   })
+
+  test('resolveFrom option', () => {
+    remark()
+      .use(includeMarkdown, {
+        resolveFrom: path.join(__dirname, 'fixtures/nested')
+      })
+      .process(loadFixture('resolve-from'), (err, file) => {
+        if (err) throw new Error(err)
+        expect(file.contents).toBe(
+          loadFixture('resolve-from.expected').contents
+        )
+      })
+  })
 })
 
 function loadFixture(name) {


### PR DESCRIPTION
This allows all partials to be located in a single folder if necessary and disables partial paths being relative to the currently processed file. This is useful in a variety of situations.

Going to quick merge for movement but feedback welcome!