### PR TITLE
Add publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ console.log(mdx.sync('some markdown content', {
 ```
 
 If you are using `next-hashicorp`, all of these plugins will be included by default.
+
+## Publishing
+
+To publish this package to [npm](https://www.npmjs.com/package/@hashicorp/remark-plugins), simply run `npm run publish`. This command will guide you through the versioning/publishing process.
+
+> **Note**: There is no build step when publishing this library. The consumer is expected to transpile the code appropriately.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "repository": "https://github.com/hashicorp/remark-plugins",
   "scripts": {
-    "test": "jest --verbose"
+    "test": "jest --verbose",
+    "publish": "npx np"
   }
 }


### PR DESCRIPTION
Small addendum to `README` and script addition to `package.json` that attempts to make the publishing process clearer/more obvious.