### PR TITLE
Permalinks prioritize aliases & fix compatibilitySlug for inline code lists

### DIFF
--- a/plugins/anchor-links/README.md
+++ b/plugins/anchor-links/README.md
@@ -75,7 +75,7 @@ This feature is intended to be used **very sparingly**. It is a nonstandard mark
 
 ## Options
 
-- `compatibilitySlug` _(function, optional)_ - if present, will generate an slug using a custom slug creation algorithm and add it to the element as an additional `__target` element. Accepts a function with the following signature `fn(text: string)`. The `text` argument is the headline text, if the `compatibilitySlug` function generates an idential slug as the default, it will not be added at all.
+- `compatibilitySlug` _(function, optional)_ - if present, will generate an slug using a custom slug creation algorithm and add it as an additional `__target` element. Accepts a function with the following signature `fn(text: string)`. The `text` argument is the headline/inline code text, if the `compatibilitySlug` function generates an idential slug as the default, it will not be added at all.
 
   > **NOTE:** Be conscious of duplicate tracking with your compatibility function. If it needs to keep track of existing slugs on the page to avoid duplicates, it must implement that functionality on its own. Default slugs are not exposed to the `compatibilitySlug` function because this offers a footgun that can easily break compatibility. The `compatibilitySlug` function should operate entirely in its own sphere -- if it happens to generate a duplicate slug, the plugin itself will remove it as compatibility isn't necessary in that instance.
 

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -112,7 +112,7 @@ describe('anchor-links', () => {
       )
     })
 
-    test('generates an extra slug if the argument is provided', () => {
+    test('generates an extra slug if the compatibilitySlug argument is provided', () => {
       expect(
         execute('# hello world', { compatibilitySlug: (_) => 'foo' })
       ).toMatch(
@@ -149,6 +149,14 @@ describe('anchor-links', () => {
           slug: 'hello-world',
           text: 'hello world',
           compatSlugs: ['_foo'],
+        })
+      )
+
+      expect(execute('# hello world ((#foo, #bar))')).toMatch(
+        expectedHeadingResult({
+          slug: 'hello-world',
+          text: 'hello world',
+          compatSlugs: ['foo', 'bar'],
         })
       )
     })
@@ -212,6 +220,33 @@ describe('anchor-links', () => {
           }),
           '</ul>',
         ].join('\n')
+      )
+    })
+
+    test('generates an extra slug if the compatibilitySlug argument is provided', () => {
+      expect(
+        execute('- `hello world`', { compatibilitySlug: (_) => 'foo' })
+      ).toMatch(
+        '<ul>',
+        expectedInlineCodeResult({
+          slug: 'hello-world',
+          text: 'hello world',
+          compatSlugs: ['foo'],
+        }),
+        '</ul>'
+      )
+    })
+
+    test('does not render duplicate compatibility slugs', () => {
+      expect(
+        execute('- `hello world`', { compatibilitySlug: (_) => 'hello-world' })
+      ).toMatch(
+        '<ul>',
+        expectedInlineCodeResult({
+          slug: 'hello-world',
+          text: 'hello world',
+        }),
+        '</ul>'
       )
     })
 
@@ -297,9 +332,9 @@ function execute(input, options = {}) {
 function expectedHeadingResult({ slug, compatSlugs, aria, text, level }) {
   const res = [`<h${level || '1'}>`]
   res.push(
-    `<a class="__permalink-h" href="#${slug}" aria-label="${
-      aria || text || slug
-    } permalink">»</a>`
+    `<a class="__permalink-h" href="#${
+      compatSlugs && compatSlugs.length ? compatSlugs[0] : slug
+    }" aria-label="${aria || text || slug} permalink">»</a>`
   )
 
   if (compatSlugs) {
@@ -333,9 +368,9 @@ function expectedInlineCodeResult({
     )
   }
   res.push(
-    `<a href="#${slug}" aria-label="${
-      aria || code || slug
-    } permalink" class="__permalink-lic">`
+    `<a href="#${
+      compatSlugs && compatSlugs.length ? compatSlugs[0] : slug
+    }" aria-label="${aria || code || slug} permalink" class="__permalink-lic">`
   )
   res.push(`<code>${code || slug}</code>`)
   res.push('</a>')


### PR DESCRIPTION
If an alias or `compatibilitySlug` is defined, its now displayed as the primary permalink. Aliases are a more "permanent" option and were previously the default on websites we are converting over from raw html permalinks. This was a request from docs engineering teams.

While here I found a small bug - the `compatibilitySlug` argument, if defined, only applied to headings, not inline code lists. So this was fixed - inline code lists now benefit from `compatibilitySlug` as well.