### PR TITLE
Bugfix

### DIFF
--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -201,7 +201,7 @@ function processAlias(node, startIndex = 0) {
 
     // now, we replace all of the old broken up pieces with a single, combined node containing
     // the full text of the alias
-    node.children.splice(startIndex, endIndex + 1, {
+    node.children.splice(startIndex, endIndex, {
       type: 'text',
       value: combinedText,
     })

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -173,6 +173,7 @@ describe('anchor-links', () => {
           '- `code_with_text_after` - explanation of code',
           '- text `followed_by_code` then more text',
           '- <a>html</a> `followed_by_code` then more text',
+          '- `code_with_text_and_link` - heres [a link](#foo) and some more text',
           '',
           'some more text',
         ])
@@ -191,6 +192,10 @@ describe('anchor-links', () => {
           }),
           '<li>text <code>followed_by_code</code> then more text</li>',
           '<li><a>html</a> <code>followed_by_code</code> then more text</li>',
+          expectedInlineCodeResult({
+            slug: 'code_with_text_and_link',
+            afterCode: ' - heres <a href="#foo">a link</a> and some more text',
+          }),
           '</ul>',
           '<p>some more text</p>',
         ].join('\n')
@@ -301,7 +306,11 @@ describe('anchor-links', () => {
     })
 
     expect(
-      execute(['- `baz` ((#\\_bar)) text', '- `quux` ((#foo wow'])
+      execute([
+        '- `baz` ((#\\_bar)) text',
+        '- `quux` ((#foo wow',
+        '- `foo` ((#\\_wow)) text [link](#test) more',
+      ])
     ).toMatch(
       [
         '<ul>',
@@ -313,6 +322,11 @@ describe('anchor-links', () => {
         expectedInlineCodeResult({
           slug: 'quux',
           afterCode: ' ((#foo wow',
+        }),
+        expectedInlineCodeResult({
+          slug: 'foo',
+          compatSlugs: ['_wow'],
+          afterCode: ' text <a href="#test">link</a> more',
         }),
         '</ul>',
       ].join('\n')


### PR DESCRIPTION
There was a little bug in the processing of anchor link aliases that contain escape characters and are followed by nodes that are not purely text. This bug was caused by me not having enough test cases and modding parser nodes through wide swaths of examples being quite difficult and confusing. However, it is now resolved, and there is test coverage to boot!