### PR TITLE
Feature: include non-markdown files

### DIFF
--- a/plugins/include-markdown/README.md
+++ b/plugins/include-markdown/README.md
@@ -31,6 +31,46 @@ Disclaimer: This content is not guaranteed to be in any way useful or truthful.
 <p>The rest of the content...</p>
 ```
 
+### File Types
+
+If you include a `.md` or `.mdx` file, its contents will be imported directly into the file, like a partial. If it has `@include` statements nested within it, they will all resolve recursively, as seen in the primary examples above
+
+If any other file extension is included, it will be displayed as the contents of a code block, with the code block language tag set as the file extension. For example:
+
+### Input
+
+Your main markdown file:
+
+```md
+# My cool page
+
+@include "test.js"
+
+The rest of the content...
+```
+
+`test.js`, in the same directory:
+
+```js
+function sayHello(name) {
+  console.log(`hello, ${name}!`)
+}
+```
+
+### Output
+
+```html
+<h1>My cool page</h1>
+<pre class="language-js">
+  <code>
+  function sayHello(name) {
+    console.log(`hello, ${name}!`)
+  }
+  </code>
+</pre>
+<p>The rest of the content...</p>
+```
+
 ### Options
 
 This plugin accepts one optional config option: `resolveFrom`. If you pass this option along with a path, all partials will resolve from the path that was passed in. For example:
@@ -46,17 +86,13 @@ With this config, you'd be able to put all your includes in a partials folder an
 It's important to note that remark applies transforms in the order that they are called. If you want your other plugins to also apply to the contents of includeed files, you need to make sure that you apply the include content plugin **before all other plugins**. For example, let's say you have two plugins, one is this one to include markdown, and the other capitalizes all text, because yelling makes you more authoritative and also it's easier to read capitalized text. If you want to ensure that your includeed content is also capitalized, here's how you'd order your plugins:
 
 ```js
-remark()
-  .use(includeMarkdown)
-  .use(capitalizeAllText)
+remark().use(includeMarkdown).use(capitalizeAllText)
 ```
 
 If you order them the opposite way, like this:
 
 ```js
-remark()
-  .use(capitalizeAllText)
-  .use(includeMarkdown)
+remark().use(capitalizeAllText).use(includeMarkdown)
 ```
 
 ...what will happen is that all your text will be capitalized _except_ for the text in includeed files. And on top of that, the include plugin wouldn't resolve the files properly, because it capitalized the word "include", which is the wrong syntax. So usually you want to make sure this plugin comes first in your plugin stack.

--- a/plugins/include-markdown/fixtures/include.js
+++ b/plugins/include-markdown/fixtures/include.js
@@ -1,0 +1,3 @@
+function sayHello(name) {
+  console.log(`hello, ${name}!`)
+}

--- a/plugins/include-markdown/fixtures/include.mdx
+++ b/plugins/include-markdown/fixtures/include.mdx
@@ -1,0 +1,1 @@
+this is an **mdx** include

--- a/plugins/include-markdown/fixtures/mdx-format.expected.md
+++ b/plugins/include-markdown/fixtures/mdx-format.expected.md
@@ -1,0 +1,5 @@
+before
+
+this is an **mdx** include
+
+after

--- a/plugins/include-markdown/fixtures/mdx-format.md
+++ b/plugins/include-markdown/fixtures/mdx-format.md
@@ -1,0 +1,5 @@
+before
+
+@include 'include.mdx'
+
+after

--- a/plugins/include-markdown/fixtures/non-markdown.expected.md
+++ b/plugins/include-markdown/fixtures/non-markdown.expected.md
@@ -1,0 +1,9 @@
+before
+
+```js
+function sayHello(name) {
+  console.log(`hello, ${name}!`)
+}
+```
+
+after

--- a/plugins/include-markdown/fixtures/non-markdown.md
+++ b/plugins/include-markdown/fixtures/non-markdown.md
@@ -1,0 +1,5 @@
+before
+
+@include 'include.js'
+
+after

--- a/plugins/include-markdown/index.test.js
+++ b/plugins/include-markdown/index.test.js
@@ -14,6 +14,26 @@ describe('include-markdown', () => {
       })
   })
 
+  test('include mdx', () => {
+    remark()
+      .use(includeMarkdown)
+      .process(loadFixture('mdx-format'), (err, file) => {
+        if (err) throw new Error(err)
+        expect(file.contents).toBe(loadFixture('mdx-format.expected').contents)
+      })
+  })
+
+  test('include non-markdown', () => {
+    remark()
+      .use(includeMarkdown)
+      .process(loadFixture('non-markdown'), (err, file) => {
+        if (err) throw new Error(err)
+        expect(file.contents).toBe(
+          loadFixture('non-markdown.expected').contents
+        )
+      })
+  })
+
   test('invalid path', () => {
     expect(() =>
       remark()
@@ -29,7 +49,7 @@ describe('include-markdown', () => {
   test('resolveFrom option', () => {
     remark()
       .use(includeMarkdown, {
-        resolveFrom: path.join(__dirname, 'fixtures/nested')
+        resolveFrom: path.join(__dirname, 'fixtures/nested'),
       })
       .process(loadFixture('resolve-from'), (err, file) => {
         if (err) throw new Error(err)


### PR DESCRIPTION
This feature expands the capabilities of the `@include` markdown plugin to pull in non-markdown files, which have their content embedded into a code block. This is helpful for pulling in prepared code examples. For example:

```md
### Some Headline

@include './test.hcl'
```

Would render out:

```html
<h3>Some Headline</h3>

<pre class='language-hcl'>
  <code>
    # hcl code example here
  </code>
</pre>
```