### PR TITLE
Add map option to Typography plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@ module.exports = {
   anchorLinks,
   paragraphCustomAlerts,
   typography,
-  includeMarkdown
+  includeMarkdown,
 }
 
 // for easy use of everything at the same time
-module.exports.allPlugins = ({ anchorLinks: anchorLinksOptions } = {}) => [
+module.exports.allPlugins = ({
+  anchorLinks: anchorLinksOptions,
+  typography: typographyOptions,
+} = {}) => [
   includeMarkdown,
   [anchorLinks, anchorLinksOptions],
   paragraphCustomAlerts,
-  typography
+  [typography, typographyOptions],
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/remark-plugins",
-  "version": "3.1.0",
+  "version": "3.1.0-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/remark-plugins",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/remark-plugins",
-  "version": "3.1.0-canary.0",
+  "version": "3.1.0-canary.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/remark-plugins",
   "description": "A potpourri of remark plugins used to process .mdx files",
-  "version": "3.1.0",
+  "version": "3.1.0-canary.0",
   "author": "Jeff Escalante",
   "bugs": "https://github.com/hashicorp/remark-plugins/issues",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/remark-plugins",
   "description": "A potpourri of remark plugins used to process .mdx files",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Jeff Escalante",
   "bugs": "https://github.com/hashicorp/remark-plugins/issues",
   "contributors": [
@@ -40,6 +40,7 @@
     "test": "jest --verbose",
     "release:patch": "release patch && npm publish",
     "release:minor": "release minor && npm publish",
-    "release:major": "release major && npm publish"
+    "release:major": "release major && npm publish",
+    "release:pre": "release pre canary && npm publish --tag=canary"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/remark-plugins",
   "description": "A potpourri of remark plugins used to process .mdx files",
-  "version": "3.1.0-canary.0",
+  "version": "3.1.0-canary.1",
   "author": "Jeff Escalante",
   "bugs": "https://github.com/hashicorp/remark-plugins/issues",
   "contributors": [

--- a/plugins/typography/README.md
+++ b/plugins/typography/README.md
@@ -1,7 +1,6 @@
 # Heading Type Styles
 
-We use a set of global classes for type styling at HashiCorp. This plugin adds type styles to the appropriate elements so that content looks as intended within rendered markdown blocks without duplicating or extending css.
-More details to come via our design system 😀
+We use a set of global classes for type styling at HashiCorp. This plugin adds type styles to the appropriate elements so that content looks as intended within rendered markdown blocks without duplicating or extending CSS.
 
 ### Input
 
@@ -25,4 +24,41 @@ Here is some more stuff...
 <h2 className='g-type-display-3'>Another title</h2>
 
 <p className='g-type-long-body'>Here is some more stuff...</p>
+```
+
+### Custom Class Mapping
+
+In rare cases, we may want to map custom `class` attributes onto specific elements. Currently, this plugin supports an `options` object, and `options.map` provides this functionality.
+
+Here is an imagined use case where all possible elements have custom `class` attributes. Any one of these elements can be omitted from the map, and it will fall back to our default `class` for that element.
+
+```js
+const options = {
+  map: {
+    h1: 'custom-1',
+    h2: 'custom-2',
+    h3: 'custom-3',
+    h4: 'custom-4',
+    h5: 'custom-5',
+    h6: 'custom-6',
+    p: 'custom-paragraph',
+    li: 'custom-list-item',
+  },
+}
+// example use with `mdx`
+const output = mdx.sync(fileContents, {
+  remarkPlugins: [[typographyPlugin, options]],
+})
+```
+
+With this configuration, and the same input as the previous example, we would expect the following output:
+
+```jsx
+<h1 className='custom-1'>Uses</h1>
+
+<p className='custom-paragraph'>Here are some uses...</p>
+
+<h2 className='custom-2'>Another title</h2>
+
+<p className='custom-paragraph'>Here is some more stuff...</p>
 ```

--- a/plugins/typography/index.js
+++ b/plugins/typography/index.js
@@ -36,10 +36,8 @@ module.exports = function typographyPlugin(options = {}) {
     })
 
     // Add typography classes to list items
-    visit(tree, 'list', (listNode) => {
-      listNode.children.map((node) => {
-        addClassName(node, getClassName('li'))
-      })
+    visit(tree, 'listItem', (node) => {
+      addClassName(node, getClassName('li'))
     })
   }
 }

--- a/plugins/typography/index.js
+++ b/plugins/typography/index.js
@@ -1,45 +1,44 @@
 const visit = require('unist-util-visit')
 
-module.exports = function typographyPlugin() {
+module.exports = function typographyPlugin(options = {}) {
+  function getClassName(elemKey) {
+    const defaultMap = {
+      h1: 'g-type-display-2',
+      h2: 'g-type-display-3',
+      h3: 'g-type-display-4',
+      h4: 'g-type-display-5',
+      h5: 'g-type-display-6',
+      h6: 'g-type-label',
+      p: 'g-type-long-body',
+      li: 'g-type-long-body',
+    }
+    const customMap = options.map || {}
+    return customMap[elemKey] || defaultMap[elemKey]
+  }
+
+  function addClassName(node, className) {
+    if (!className) return true
+    const data = node.data || (node.data = {})
+    const props = data.hProperties || (data.hProperties = {})
+    data.id = className
+    props.className = className
+  }
+
   return function transformer(tree) {
     // Add typography classes to headings
-    visit(tree, 'heading', node => {
-      const data = node.data || (node.data = {})
-      const props = data.hProperties || (data.hProperties = {})
+    visit(tree, 'heading', (node) => {
+      addClassName(node, getClassName(`h${node.depth}`))
+    })
 
-      if (node.depth === 1) {
-        data.id = 'g-type-display-2'
-        props.className = 'g-type-display-2'
-      }
-      if (node.depth === 2) {
-        data.id = 'g-type-display-3'
-        props.className = 'g-type-display-3'
-      }
-      if (node.depth === 3) {
-        data.id = 'g-type-display-4'
-        props.className = 'g-type-display-4'
-      }
-      if (node.depth === 4) {
-        data.id = 'g-type-display-5'
-        props.className = 'g-type-display-5'
-      }
-      if (node.depth === 5) {
-        data.id = 'g-type-display-6'
-        props.className = 'g-type-display-6'
-      }
-      if (node.depth === 6) {
-        data.id = 'g-type-label'
-        props.className = 'g-type-label'
-      }
+    // Add typography classes to paragraph text
+    visit(tree, 'paragraph', (node) => {
+      addClassName(node, getClassName('p'))
     })
 
     // Add typography classes to list items
-    visit(tree, 'list', node => {
-      node.children.map(li => {
-        const data = li.data || (li.data = {})
-        const props = data.hProperties || (data.hProperties = {})
-        data.id = 'g-type-long-body'
-        props.className = 'g-type-long-body'
+    visit(tree, 'list', (listNode) => {
+      listNode.children.map((node) => {
+        addClassName(node, getClassName('li'))
       })
     })
   }

--- a/plugins/typography/index.test.js
+++ b/plugins/typography/index.test.js
@@ -1,4 +1,4 @@
-const typeStyles = require('./index.js')
+const typographyPlugin = require('./index.js')
 const mdx = require('@mdx-js/mdx')
 
 const fileContents = `hi there
@@ -19,16 +19,73 @@ Foo bar baz wow *amaze*
 `
 
 describe('type-styles', () => {
-  it('should construct add appropriate class names to headings', () => {
-    const output = mdx.sync(fileContents, { remarkPlugins: [typeStyles] })
+  it('adds classNames to headings, paragraphs, and list items', () => {
+    const output = mdx.sync(fileContents, { remarkPlugins: [typographyPlugin] })
     expect(output).toMatch(
       /<h1 {\.\.\.{\n\s+"className": "g-type-display-2"\n\s+}}>{`Heading One`}<\/h1>/
+    )
+    expect(output).toMatch(
+      /<h2 {\.\.\.{\n\s+"className": "g-type-display-3"\n\s+}}>{`Heading Two`}<\/h2>/
+    )
+    expect(output).toMatch(
+      /<h3 {\.\.\.{\n\s+"className": "g-type-display-4"\n\s+}}>{`Heading Three`}<\/h3>/
+    )
+    expect(output).toMatch(
+      /<h4 {\.\.\.{\n\s+"className": "g-type-display-5"\n\s+}}>{`Heading Four`}<\/h4>/
+    )
+    expect(output).toMatch(
+      /<h5 {\.\.\.{\n\s+"className": "g-type-display-6"\n\s+}}>{`Heading Five`}<\/h5>/
     )
     expect(output).toMatch(
       /<h6 {\.\.\.{\n\s+"className": "g-type-label"\n\s+}}>{`Heading Six`}<\/h6>/
     )
     expect(output).toMatch(
+      /<p {\.\.\.{\n\s+"className": "g-type-long-body"\n\s+}}>{`sadklfjhlskdjf`}<\/p>/
+    )
+    expect(output).toMatch(
       /<li parentName="ul" {\.\.\.{\n\s+"className": "g-type-long-body"\n\s+}}>{`foo`}<\/li>/
+    )
+  })
+
+  it('allows customization of classNames', () => {
+    const options = {
+      map: {
+        h1: 'custom-1',
+        h2: 'custom-2',
+        h3: 'custom-3',
+        h4: 'custom-4',
+        h5: 'custom-5',
+        h6: 'custom-6',
+        p: 'custom-paragraph',
+        li: 'custom-list-item',
+      },
+    }
+    const output = mdx.sync(fileContents, {
+      remarkPlugins: [[typographyPlugin, options]],
+    })
+    expect(output).toMatch(
+      /<h1 {\.\.\.{\n\s+"className": "custom-1"\n\s+}}>{`Heading One`}<\/h1>/
+    )
+    expect(output).toMatch(
+      /<h2 {\.\.\.{\n\s+"className": "custom-2"\n\s+}}>{`Heading Two`}<\/h2>/
+    )
+    expect(output).toMatch(
+      /<h3 {\.\.\.{\n\s+"className": "custom-3"\n\s+}}>{`Heading Three`}<\/h3>/
+    )
+    expect(output).toMatch(
+      /<h4 {\.\.\.{\n\s+"className": "custom-4"\n\s+}}>{`Heading Four`}<\/h4>/
+    )
+    expect(output).toMatch(
+      /<h5 {\.\.\.{\n\s+"className": "custom-5"\n\s+}}>{`Heading Five`}<\/h5>/
+    )
+    expect(output).toMatch(
+      /<h6 {\.\.\.{\n\s+"className": "custom-6"\n\s+}}>{`Heading Six`}<\/h6>/
+    )
+    expect(output).toMatch(
+      /<p {\.\.\.{\n\s+"className": "custom-paragraph"\n\s+}}>{`sadklfjhlskdjf`}<\/p>/
+    )
+    expect(output).toMatch(
+      /<li parentName="ul" {\.\.\.{\n\s+"className": "custom-list-item"\n\s+}}>{`foo`}<\/li>/
     )
   })
 })


### PR DESCRIPTION
### Briefly

This PR adds a `map` option to the `typography` plugin. This enables custom mapping of `classNames` onto heading, paragraph, and list item elements.

This PR also adds a `g-type-long-body` class to `<p />` tags, to ensure they're styled correctly.

Tests have also been updated to test these additional features.

### Why

This functionality is intended to meet the need for different `className` values in different long-form content contexts.

Specifically, in the recent Blog redesign, we want to avoid type styles larger than `g-type-display-3` within Blog content, and we also want to avoid using the "label" type style for headings. This functionality lets us achieve this, while maintaining existing `heading element` to `display style` mapping on other projects, such as Learn and Docs.

We also have a use case for [`BeforeAfterDiagram`](https://github.com/hashicorp/hashicorp-www-next/pull/1756/), which will allow us to avoid duplicating `g-type-*` CSS.

### Example Use

An example use of the option for the Blog case would be:

```js
const output = mdx.sync(markdown, {
  remarkPlugins: [
    [
      typographyPlugin,
      {
        map: {
          h1: 'g-type-display-3',
          h2: 'g-type-display-4',
          h3: 'g-type-display-5',
          h4: 'g-type-display-6',
          h5: 'g-type-display-6',
          h6: 'g-type-display-6',
        },
      }
    ]
  ],
})
```

### Compatibility

The `typography` plugin can continue to be used without options, which yields the same `className` mappings as before, specifically:

```js
const defaultMap = {
  h1: 'g-type-display-2',
  h2: 'g-type-display-3',
  h3: 'g-type-display-4',
  h4: 'g-type-display-5',
  h5: 'g-type-display-6',
  h6: 'g-type-label',
  li: 'g-type-long-body',
  p: 'g-type-long-body', // new addition in this PR, to ensure correct styling
}
```

### Alternative approaches

One alternative approach would be to keep the mappings static, and enforce content changes, such as only using `### Heading 3` or smaller headings in markdown. However, this would be cumbersome for authors, might be semantically incorrect, and would require changes to all previous blog post content.

Another option would be to forego the `typography` plugin on Blog, and use MDX components instead - for example, `h1: (text) => <h1 className="g-type-display-1"></h1>`. This might align nicely with our use of `mdx-remote`, and might also align with a transition to CSS modules, which when combined with MDX components might make it easier to prevent `.g-content` styles from leaking to places we don't want them to. However, this would not provide a solution for non-MDX contexts, and feels like it may be a higher level of effort than making this plugin a bit more customizable.

Finally, another option might be to try to abstract this plugin into a more generic `addClassNames` plugin, which would accept a map HTML elements to classNames, and add the classNames to the (`mdast`)[https://github.com/syntax-tree/mdast#nodes] nodes' `data.hProperties` objects. However, we don't have an immediate need for this plugin, so not taking this approach for now.