### PR TITLE
Allow empty strings to prevent typography class additions

### DIFF
--- a/plugins/typography/index.js
+++ b/plugins/typography/index.js
@@ -13,7 +13,9 @@ module.exports = function typographyPlugin(options = {}) {
       li: 'g-type-long-body',
     }
     const customMap = options.map || {}
-    return customMap[elemKey] || defaultMap[elemKey]
+    return typeof customMap[elemKey] === 'string'
+      ? customMap[elemKey]
+      : defaultMap[elemKey]
   }
 
   function addClassName(node, className) {

--- a/plugins/typography/index.test.js
+++ b/plugins/typography/index.test.js
@@ -47,6 +47,21 @@ describe('type-styles', () => {
     )
   })
 
+  it('allows empty strings in map to prevent the addition of classNames', () => {
+    const options = {
+      map: {
+        p: '',
+      },
+    }
+    const output = mdx.sync(fileContents, {
+      remarkPlugins: [[typographyPlugin, options]],
+    })
+    console.log(output)
+    expect(output).not.toMatch(
+      /<p {\.\.\.{\n\s+"className": "g-type-long-body"\n\s+}}>{`sadklfjhlskdjf`}<\/p>/
+    )
+  })
+
   it('allows customization of classNames', () => {
     const options = {
       map: {

--- a/plugins/typography/index.test.js
+++ b/plugins/typography/index.test.js
@@ -56,7 +56,6 @@ describe('type-styles', () => {
     const output = mdx.sync(fileContents, {
       remarkPlugins: [[typographyPlugin, options]],
     })
-    console.log(output)
     expect(output).not.toMatch(
       /<p {\.\.\.{\n\s+"className": "g-type-long-body"\n\s+}}>{`sadklfjhlskdjf`}<\/p>/
     )


### PR DESCRIPTION
This PR makes a slight modification to the `typography` plugin to allow it to accept empty strings in the `map` option. This enables consumers to remove custom typography classes completely (rather than passing a meaningless non-empty string such as `" "` to achieve the same result).