### PR TITLE
Removes alert role from custom plugin

### DIFF
--- a/plugins/paragraph-custom-alerts/index.js
+++ b/plugins/paragraph-custom-alerts/index.js
@@ -5,20 +5,20 @@ const sigils = {
   '=>': 'success',
   '->': 'info',
   '~>': 'warning',
-  '!>': 'danger'
+  '!>': 'danger',
 }
 
 module.exports = function paragraphCustomAlertsPlugin() {
   return function transformer(tree) {
     visit(tree, 'paragraph', (pNode, _, parent) => {
-      visit(pNode, 'text', textNode => {
-        Object.keys(sigils).forEach(symbol => {
+      visit(pNode, 'text', (textNode) => {
+        Object.keys(sigils).forEach((symbol) => {
           if (textNode.value.startsWith(`${symbol} `)) {
             // Remove the literal sigil symbol from string contents
             textNode.value = textNode.value.replace(`${symbol} `, '')
 
             // Wrap matched nodes with <div> (containing proper attributes)
-            parent.children = parent.children.map(node => {
+            parent.children = parent.children.map((node) => {
               return is(pNode, node)
                 ? {
                     type: 'wrapper',
@@ -29,11 +29,10 @@ module.exports = function paragraphCustomAlertsPlugin() {
                         className: [
                           'alert',
                           `alert-${sigils[symbol]}`,
-                          'g-type-body'
+                          'g-type-body',
                         ],
-                        role: 'alert'
-                      }
-                    }
+                      },
+                    },
                   }
                 : node
             })


### PR DESCRIPTION
See [Asana task](https://app.asana.com/0/1100423001970639/1201088511749812) for context.

> I was testing a new toast feature on learn with VO and I was met with these intense interruptions to the flow of content. Basically I would land on a page and immediately the content in a markdown alert (block-quote) would be read, skipping everything else, and they are normally pretty far nested into the content. 

This doesn't feel like an appropriate use for the alert role, so it is removed in this PR. I think it's normally used sparingly for pressing, dynamic, time-sensitive data, rather than a 'note' or blockquote an author made deep within the page content. 