### PR TITLE
Adding support for optional headings option

### DIFF
--- a/plugins/anchor-links/README.md
+++ b/plugins/anchor-links/README.md
@@ -79,4 +79,12 @@ This feature is intended to be used **very sparingly**. It is a nonstandard mark
 
   > **NOTE:** Be conscious of duplicate tracking with your compatibility function. If it needs to keep track of existing slugs on the page to avoid duplicates, it must implement that functionality on its own. Default slugs are not exposed to the `compatibilitySlug` function because this offers a footgun that can easily break compatibility. The `compatibilitySlug` function should operate entirely in its own sphere -- if it happens to generate a duplicate slug, the plugin itself will remove it as compatibility isn't necessary in that instance.
 
+- `headings` _(array, optional)_ - if present, data about the headings being processed will be pushed to the array. Each element is an object with the following properties:
+
+  - `aliases`: a string array containing all of the given [anchor link aliases](#anchor-link-aliases) for a heading
+  - `level`: the level of a heading (e.g. an `<h1>` has a level of 1 and an `<h2>` has a level of 2)
+  - `permalinkSlug`: the slug used in the permalink element
+  - `slug`: the slug generated from a heading's text
+  - `title`: the content of a heading excluding the anchor link aliases
+
 - `listWithInlineCodePrefix` _(string, optional)_ - if present, will append a string to the beginning of each instance where lists with inline code at the beginning get an anchor link. This is also provided for compatibility reasons, as we previously used a separate plugin for lists with inline code that appended an `inlinecode` prefix to avoid conflicts.

--- a/plugins/anchor-links/README.md
+++ b/plugins/anchor-links/README.md
@@ -2,7 +2,7 @@
 
 This plugin processes headings and inline code blocks at the beginning of a list item to generate a slug and adds a **permalink** element and an invisible **target** element. These two elements ensure that users are able to click a link next to the heading, or click on the inline code block to quickly get an anchor link directly to the corresponding section, and that developers are able to customize the position that the section appears when that anchor link is visited, respectively.
 
-### Input:
+## Input:
 
 ```mdx
 # First Level Heading
@@ -13,7 +13,7 @@ This plugin processes headings and inline code blocks at the beginning of a list
 Content here...
 ```
 
-### Output:
+## Output:
 
 ```html
 <h1>

--- a/plugins/anchor-links/README.md
+++ b/plugins/anchor-links/README.md
@@ -85,6 +85,6 @@ This feature is intended to be used **very sparingly**. It is a nonstandard mark
   - `level`: the level of a heading (e.g. an `<h1>` has a level of 1 and an `<h2>` has a level of 2)
   - `permalinkSlug`: the slug used in the permalink element
   - `slug`: the slug generated from a heading's text
-  - `title`: the content of a heading excluding the anchor link aliases
+  - `title`: the content of a heading in plain text (excluding aliases)
 
 - `listWithInlineCodePrefix` _(string, optional)_ - if present, will append a string to the beginning of each instance where lists with inline code at the beginning get an anchor link. This is also provided for compatibility reasons, as we previously used a separate plugin for lists with inline code that appended an `inlinecode` prefix to avoid conflicts.

--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -104,11 +104,11 @@ function processHeading(node, compatibilitySlug, links) {
   })
 
   const headingData = {
-    title,
-    level,
-    slug,
     aliases,
+    level,
     permalinkSlug,
+    slug,
+    title,
   }
   return [node, headingData]
 }

--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -54,6 +54,7 @@ function processHeading(node, compatibilitySlug, links, headings) {
   const level = node.depth
   const title = text
     .substring(level + 1)
+    .replace(/<\/?[^>]*>/g, '') // Strip html
     .replace(/\(\(#.*?\)\)/g, '') // Strip anchor link aliases
     .replace(/\s+/g, ' ') // Collapse whitespace
     .trim()

--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -25,13 +25,7 @@ module.exports = function anchorLinksPlugin({
       //
       // start with headings
       if (is(node, 'heading')) {
-        const [processedNode, headingData] = processHeading(
-          node,
-          compatibilitySlug,
-          links
-        )
-        headings?.push(headingData)
-        return processedNode
+        return processHeading(node, compatibilitySlug, links, headings)
       }
 
       // next we check for lists with inline code. specifically, we're looking for:
@@ -55,7 +49,7 @@ module.exports = function anchorLinksPlugin({
   }
 }
 
-function processHeading(node, compatibilitySlug, links) {
+function processHeading(node, compatibilitySlug, links, headings) {
   const text = stringifyChildNodes(node)
   const level = node.depth
   const title = text
@@ -110,7 +104,9 @@ function processHeading(node, compatibilitySlug, links) {
     slug,
     title,
   }
-  return [node, headingData]
+  headings?.push(headingData)
+
+  return node
 }
 
 function processListWithInlineCode(

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -166,7 +166,7 @@ describe('anchor-links', () => {
         execute(
           [
             '# hello world <a href="wow"></a>',
-            '# hello <a href="wow"></a> world',
+            '# hello <a href="wow">world</a>',
           ],
           { headings }
         )
@@ -179,7 +179,7 @@ describe('anchor-links', () => {
           }),
           expectedHeadingResult({
             slug: 'hello-world-1',
-            text: 'hello <a href="wow"></a> world',
+            text: 'hello <a href="wow">world</a>',
             aria: 'hello world',
           }),
         ].join('\n')
@@ -191,14 +191,14 @@ describe('anchor-links', () => {
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
-          "title": "hello world <a href=\\"wow\\"></a>",
+          "title": "hello world",
         },
         Object {
           "aliases": undefined,
           "level": 1,
           "permalinkSlug": "hello-world-1",
           "slug": "hello-world-1",
-          "title": "hello <a href=\\"wow\\"></a> world",
+          "title": "hello world",
         },
       ]
       `)
@@ -236,7 +236,7 @@ describe('anchor-links', () => {
           "level": 1,
           "permalinkSlug": "hello-world-1",
           "slug": "hello-world-1",
-          "title": "<a></a> hello world",
+          "title": "hello world",
         },
       ]
       `)

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -1,9 +1,6 @@
-const generateSlug = require('../../generate_slug')
 const remark = require('remark')
 const html = require('remark-html')
 const anchorLinks = require('./index.js')
-
-console.log('--->', generateSlug.generateAriaLabel('# hello world ((#foo))'))
 
 describe('anchor-links', () => {
   describe('headings', () => {
@@ -26,6 +23,67 @@ describe('anchor-links', () => {
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
           "title": "hello world",
+        },
+      ]
+      `)
+    })
+
+    test('multiple heading levels', () => {
+      const headings = []
+      execute(
+        [
+          '# Heading 1',
+          '## Heading 2',
+          '### Heading 3',
+          '#### Heading 4',
+          '##### Heading 5',
+          '###### Heading 6',
+        ],
+        { headings }
+      )
+      expect(headings).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "aliases": undefined,
+          "level": 1,
+          "permalinkSlug": "heading-1",
+          "slug": "heading-1",
+          "title": "Heading 1",
+        },
+        Object {
+          "aliases": undefined,
+          "level": 2,
+          "permalinkSlug": "heading-2",
+          "slug": "heading-2",
+          "title": "Heading 2",
+        },
+        Object {
+          "aliases": undefined,
+          "level": 3,
+          "permalinkSlug": "heading-3",
+          "slug": "heading-3",
+          "title": "Heading 3",
+        },
+        Object {
+          "aliases": undefined,
+          "level": 4,
+          "permalinkSlug": "heading-4",
+          "slug": "heading-4",
+          "title": "Heading 4",
+        },
+        Object {
+          "aliases": undefined,
+          "level": 5,
+          "permalinkSlug": "heading-5",
+          "slug": "heading-5",
+          "title": "Heading 5",
+        },
+        Object {
+          "aliases": undefined,
+          "level": 6,
+          "permalinkSlug": "heading-6",
+          "slug": "heading-6",
+          "title": "Heading 6",
         },
       ]
       `)
@@ -377,19 +435,23 @@ describe('anchor-links', () => {
 
   describe('lists starting with inline code', () => {
     test('basic', () => {
+      const headings = []
       expect(
-        execute([
-          'some text',
-          '',
-          '- raw text',
-          '- `code with spaces`',
-          '- `code_with_text_after` - explanation of code',
-          '- text `followed_by_code` then more text',
-          '- <a>html</a> `followed_by_code` then more text',
-          '- `code_with_text_and_link` - heres [a link](#foo) and some more text',
-          '',
-          'some more text',
-        ])
+        execute(
+          [
+            'some text',
+            '',
+            '- raw text',
+            '- `code with spaces`',
+            '- `code_with_text_after` - explanation of code',
+            '- text `followed_by_code` then more text',
+            '- <a>html</a> `followed_by_code` then more text',
+            '- `code_with_text_and_link` - heres [a link](#foo) and some more text',
+            '',
+            'some more text',
+          ],
+          { headings }
+        )
       ).toMatch(
         [
           '<p>some text</p>',
@@ -413,10 +475,12 @@ describe('anchor-links', () => {
           '<p>some more text</p>',
         ].join('\n')
       )
+      expect(headings).toMatchInlineSnapshot('Array []')
     })
 
     test('duplicate slugs', () => {
-      expect(execute(['- `foo`', '- `foo`'])).toMatch(
+      const headings = []
+      expect(execute(['- `foo`', '- `foo`'], { headings })).toMatch(
         [
           '<ul>',
           expectedInlineCodeResult({ slug: 'foo' }),
@@ -424,11 +488,13 @@ describe('anchor-links', () => {
           '</ul>',
         ].join('\n')
       )
+      expect(headings).toMatchInlineSnapshot('Array []')
     })
 
     test('prefix option', () => {
+      const headings = []
       expect(
-        execute('- `foo`', { listWithInlineCodePrefix: 'inlinecode' })
+        execute('- `foo`', { headings, listWithInlineCodePrefix: 'inlinecode' })
       ).toMatch(
         [
           '<ul>',
@@ -439,11 +505,16 @@ describe('anchor-links', () => {
           '</ul>',
         ].join('\n')
       )
+      expect(headings).toMatchInlineSnapshot('Array []')
     })
 
     test('generates an extra slug if the compatibilitySlug argument is provided', () => {
+      const headings = []
       expect(
-        execute('- `hello world`', { compatibilitySlug: (_) => 'foo' })
+        execute('- `hello world`', {
+          compatibilitySlug: (_) => 'foo',
+          headings,
+        })
       ).toMatch(
         '<ul>',
         expectedInlineCodeResult({
@@ -453,11 +524,16 @@ describe('anchor-links', () => {
         }),
         '</ul>'
       )
+      expect(headings).toMatchInlineSnapshot('Array []')
     })
 
     test('does not render duplicate compatibility slugs', () => {
+      const headings = []
       expect(
-        execute('- `hello world`', { compatibilitySlug: (_) => 'hello-world' })
+        execute('- `hello world`', {
+          compatibilitySlug: (_) => 'hello-world',
+          headings,
+        })
       ).toMatch(
         '<ul>',
         expectedInlineCodeResult({
@@ -466,10 +542,12 @@ describe('anchor-links', () => {
         }),
         '</ul>'
       )
+      expect(headings).toMatchInlineSnapshot('Array []')
     })
 
     test('duplicate slug with headline', () => {
-      expect(execute(['# foo', '', '- `foo`'])).toMatch(
+      const headings = []
+      expect(execute(['# foo', '', '- `foo`'], { headings })).toMatch(
         [
           expectedHeadingResult({ slug: 'foo' }),
           '<ul>',
@@ -477,11 +555,24 @@ describe('anchor-links', () => {
           '</ul>',
         ].join('\n')
       )
+      expect(headings).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "aliases": undefined,
+          "level": 1,
+          "permalinkSlug": "foo",
+          "slug": "foo",
+          "title": "foo",
+        },
+      ]
+      `)
     })
 
     test('duplicate slug with headline and prefix option', () => {
+      const headings = []
       expect(
         execute(['# foo', '', '- `foo`'], {
+          headings,
           listWithInlineCodePrefix: 'inlinecode',
         })
       ).toMatch(
@@ -495,15 +586,30 @@ describe('anchor-links', () => {
           '</ul>',
         ].join('\n')
       )
+      expect(headings).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "aliases": undefined,
+          "level": 1,
+          "permalinkSlug": "foo",
+          "slug": "foo",
+          "title": "foo",
+        },
+      ]
+      `)
     })
 
     test('anchor aliases', () => {
+      let headings = []
       expect(
-        execute([
-          '- `foo` ((#bar)) - other text',
-          '- `foo` ((#baz, #quux))',
-          '- `foo` some text ((#wow)) more text', // this one *shouldn't* work but it does currently
-        ])
+        execute(
+          [
+            '- `foo` ((#bar)) - other text',
+            '- `foo` ((#baz, #quux))',
+            '- `foo` some text ((#wow)) more text', // this one *shouldn't* work but it does currently
+          ],
+          { headings }
+        )
       ).toMatch(
         [
           '<ul>',
@@ -526,14 +632,19 @@ describe('anchor-links', () => {
           '</ul>',
         ].join('\n')
       )
+      expect(headings).toMatchInlineSnapshot('Array []')
     })
 
+    headings = []
     expect(
-      execute([
-        '- `baz` ((#\\_bar)) text',
-        '- `quux` ((#foo wow',
-        '- `foo` ((#\\_wow)) text [link](#test) more',
-      ])
+      execute(
+        [
+          '- `baz` ((#\\_bar)) text',
+          '- `quux` ((#foo wow',
+          '- `foo` ((#\\_wow)) text [link](#test) more',
+        ],
+        { headings }
+      )
     ).toMatch(
       [
         '<ul>',
@@ -554,6 +665,7 @@ describe('anchor-links', () => {
         '</ul>',
       ].join('\n')
     )
+    expect(headings).toMatchInlineSnapshot('Array []')
   })
 })
 

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -89,6 +89,11 @@ describe('anchor-links', () => {
       `)
     })
 
+    test('without headings option', () => {
+      execute('# hello world')
+      expect(headings).toMatchInlineSnapshot(`Array []`)
+    })
+
     test('duplicate slugs', () => {
       const headings = []
       expect(


### PR DESCRIPTION
🔗  [Asana task](https://app.asana.com/0/1100423001970639/1201314477034614/f)

This PR adds support for a new `headings` option for `anchor-links`. This option enables us to pass an array to be populated with heading data so we can create useful components like tables of contents that link to headings without having to query a document for heading elements and parse them for permalinks.

The original idea was to create a new plugin for this, but the `anchor-links` plugin has a lot of complex logic for handling duplicate headings and custom link aliasing that is easier to use within the plugin than abstract for reuse. We also have not come up with a use case yet where these plugins would not be used together.