### PR TITLE
Fixing default values for aliases heading property

### DIFF
--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -68,7 +68,7 @@ function processHeading(node, compatibilitySlug, links, headings) {
 
   // handle anchor link aliases
   const aliases = processAlias(node, 1)
-  if (aliases) node.children.unshift(...aliasesToNodes(aliases, 'h'))
+  if (aliases.length) node.children.unshift(...aliasesToNodes(aliases, 'h'))
 
   // if the compatibilitySlug option is present, we generate it and add it
   // if it doesn't already match the existing slug
@@ -125,7 +125,7 @@ function processListWithInlineCode(
 
   // handle anchor link aliases
   const aliases = processAlias(pNode, 1)
-  if (aliases) liNode.children.unshift(...aliasesToNodes(aliases, 'lic'))
+  if (aliases.length) liNode.children.unshift(...aliasesToNodes(aliases, 'lic'))
 
   // if the compatibilitySlug option is present, we generate it and add it
   // if it doesn't already match the existing slug
@@ -177,7 +177,7 @@ function processAlias(node, startIndex = 0) {
     !node.children.length ||
     node.children.length <= startIndex
   )
-    return
+    return []
 
   // with the below regex, we look for ((#foo)) or ((#foo, #bar))
   //
@@ -226,7 +226,9 @@ function processAlias(node, startIndex = 0) {
     )
 
     // If there is a "((" pattern without a closing, never mind
-    if (endIndex < 0) return
+    if (endIndex < 0) {
+      return []
+    }
 
     // we know where the beginning and end nodes containing our pattern are, so we combine
     // their values into a single string
@@ -247,6 +249,8 @@ function processAlias(node, startIndex = 0) {
     // and then proceed to process it as if none of this ever happened!
     return _processAliases(node.children[startIndex], aliasRegex)
   }
+
+  return []
 }
 
 function _processAliases(node, aliasRegex) {
@@ -260,7 +264,7 @@ function _processAliases(node, aliasRegex) {
   node.value = node.value.replace(aliasRegex, '')
 
   // and return the aliases
-  return aliases
+  return aliases || []
 }
 
 // This converts a raw array of aliases to html "target" nodes

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -18,7 +18,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
@@ -44,42 +44,42 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "heading-1",
           "slug": "heading-1",
           "title": "Heading 1",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 2,
           "permalinkSlug": "heading-2",
           "slug": "heading-2",
           "title": "Heading 2",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 3,
           "permalinkSlug": "heading-3",
           "slug": "heading-3",
           "title": "Heading 3",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 4,
           "permalinkSlug": "heading-4",
           "slug": "heading-4",
           "title": "Heading 4",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 5,
           "permalinkSlug": "heading-5",
           "slug": "heading-5",
           "title": "Heading 5",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 6,
           "permalinkSlug": "heading-6",
           "slug": "heading-6",
@@ -122,35 +122,35 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
           "title": "hello world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world-1",
           "slug": "hello-world-1",
           "title": "hello world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "foo",
           "slug": "foo",
           "title": "foo",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world-2",
           "slug": "hello-world-2",
           "title": "hello world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "foo-1",
           "slug": "foo-1",
@@ -187,14 +187,14 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
           "title": "hello world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world-1",
           "slug": "hello-world-1",
@@ -225,14 +225,14 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
           "title": "- hello world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world-1",
           "slug": "hello-world-1",
@@ -271,21 +271,21 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
           "title": "hEllO----world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world-1",
           "slug": "hello-world-1",
           "title": "hello :&-- world",
         },
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world-foo",
           "slug": "hello-world-foo",
@@ -309,7 +309,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "foo",
           "slug": "hello-world",
@@ -335,7 +335,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "hello-world",
           "slug": "hello-world",
@@ -563,7 +563,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "foo",
           "slug": "foo",
@@ -594,7 +594,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`
       Array [
         Object {
-          "aliases": undefined,
+          "aliases": Array [],
           "level": 1,
           "permalinkSlug": "foo",
           "slug": "foo",


### PR DESCRIPTION
This PR changes the default value for the `aliases` properties under the new `headings` option to be empty arrays instead of `undefined`. Without this change, errors like the following can occur in `getStaticProps` functions where the `anchor-links` plugin is used:

```
error - SerializableError: Error serializing `.headings[0].aliases` returned from `getStaticProps` in "/waypoint/docs/[[...page]]".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```