### PR TITLE
feat(anchor-links): report tabbed section depth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/remark-plugins",
-  "version": "4.0.1-canary.0",
+  "version": "4.0.1-canary.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/remark-plugins",
-  "version": "4.0.1",
+  "version": "4.0.1-canary.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/remark-plugins",
   "description": "A potpourri of remark plugins used to process .mdx files",
-  "version": "4.0.1",
+  "version": "4.0.1-canary.0",
   "author": "Jeff Escalante",
   "bugs": "https://github.com/hashicorp/remark-plugins/issues",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hashicorp/remark-plugins",
   "description": "A potpourri of remark plugins used to process .mdx files",
-  "version": "4.0.1-canary.0",
+  "version": "4.0.1-canary.1",
   "author": "Jeff Escalante",
   "bugs": "https://github.com/hashicorp/remark-plugins/issues",
   "contributors": [

--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -32,8 +32,8 @@ module.exports = function anchorLinksPlugin({
        * If it opens <Tabs>, increase the tabbedSectionDepth.
        * If it closes </Tabs>, decrease the tabbedSectionDepth.
        */
-      const isHtmlNode = node.type === 'html'
-      if (isHtmlNode) {
+      const isHtmlOrJsxNode = node.type === 'html' || node.type === 'jsx'
+      if (isHtmlOrJsxNode) {
         // Note that a single HTML node could potentially contain multiple tags
         const openTagMatches = node.value.match(/\<Tabs/)
         const openTagCount = openTagMatches ? openTagMatches.length : 0

--- a/plugins/anchor-links/index.js
+++ b/plugins/anchor-links/index.js
@@ -29,28 +29,24 @@ module.exports = function anchorLinksPlugin({
     return map(tree, (node) => {
       /**
        * Check if this node opens or closes <Tabs />.
-       * If it opens <Tabs>, increase the tabbedSectionDepth by 1.
-       * If it closes </Tabs>, decrease the tabbedSectionDepth by 1.
+       * If it opens <Tabs>, increase the tabbedSectionDepth.
+       * If it closes </Tabs>, decrease the tabbedSectionDepth.
        */
-      // console.log({ node })
       const isHtmlNode = node.type === 'html'
       if (isHtmlNode) {
-        const isTabsOpening = /\<Tabs/.test(node.value)
-        const isTabsClosing = /\<\/Tabs/.test(node.value)
-        if (isTabsOpening) {
-          tabbedSectionDepth += 1
-        } else if (isTabsClosing) {
-          tabbedSectionDepth -= 1
-        }
-
-        // console.log({ isTabsOpening, isTabsClosing })
+        // Note that a single HTML node could potentially contain multiple tags
+        const openTagMatches = node.value.match(/\<Tabs/)
+        const openTagCount = openTagMatches ? openTagMatches.length : 0
+        tabbedSectionDepth += openTagCount
+        const closeTagMatches = node.value.match(/\<\/Tabs/)
+        const closeTagCount = closeTagMatches ? closeTagMatches.length : 0
+        tabbedSectionDepth -= closeTagCount
       }
 
       // since we are adding anchor links to two separate patterns: headings and
       // lists with inline code, we first sort into these categories.
       //
       // start with headings
-      // console.log({ isWithinTabs, tabbedSectionDepth })
       if (is(node, 'heading')) {
         return processHeading(
           node,

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -93,7 +93,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`Array []`)
     })
 
-    test('ignores headings in <Tabs/>', () => {
+    test.only('ignores headings in <Tabs/>', () => {
       const headings = []
       const lines = `# Root Heading
 
@@ -128,13 +128,31 @@ Object {
   "level": 1,
   "permalinkSlug": "root-heading",
   "slug": "root-heading",
+  "tabbedSectionDepth": 0,
   "title": "Root Heading",
+},
+Object {
+  "aliases": Array [],
+  "level": 2,
+  "permalinkSlug": "first-tab-heading",
+  "slug": "first-tab-heading",
+  "tabbedSectionDepth": 1,
+  "title": "First Tab Heading",
+},
+Object {
+  "aliases": Array [],
+  "level": 2,
+  "permalinkSlug": "second-tab-heading",
+  "slug": "second-tab-heading",
+  "tabbedSectionDepth": 1,
+  "title": "Second Tab Heading",
 },
 Object {
   "aliases": Array [],
   "level": 2,
   "permalinkSlug": "heading-after-tabs",
   "slug": "heading-after-tabs",
+  "tabbedSectionDepth": 0,
   "title": "Heading After Tabs",
 },
 ]`)

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -93,6 +93,40 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`Array []`)
     })
 
+    test('ignores headings in <Tabs/>', () => {
+      const headings = []
+      const lines = `# Root Heading
+
+<Tabs>
+
+<Tab>
+
+## First Tab Heading
+
+Some content in the first tab.
+
+</Tab>
+
+<Tab>
+
+## Second Tab Heading
+
+Second tab also has content
+
+</Tab>
+
+</Tabs>
+
+## Heading After Tabs
+
+Words written after the tabbed section, not within it.
+      `.split('\n')
+
+      console.log({ lines })
+      execute(lines, { headings })
+      expect(headings).toMatchInlineSnapshot(`Array []`)
+    })
+
     test('duplicate slugs', () => {
       const headings = []
       expect(

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -121,10 +121,23 @@ Second tab also has content
 
 Words written after the tabbed section, not within it.
       `.split('\n')
-
-      console.log({ lines })
       execute(lines, { headings })
-      expect(headings).toMatchInlineSnapshot(`Array []`)
+      expect(headings).toMatchInlineSnapshot(`Array [
+Object {
+  "aliases": Array [],
+  "level": 1,
+  "permalinkSlug": "root-heading",
+  "slug": "root-heading",
+  "title": "Root Heading",
+},
+Object {
+  "aliases": Array [],
+  "level": 2,
+  "permalinkSlug": "heading-after-tabs",
+  "slug": "heading-after-tabs",
+  "title": "Heading After Tabs",
+},
+]`)
     })
 
     test('duplicate slugs', () => {

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -100,7 +100,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`Array []`)
     })
 
-    test('ignores headings in <Tabs/>', () => {
+    test('adds correct tabbedSectionDepth for headings in <Tabs/>', () => {
       const headings = []
       const lines = `# Root Heading
 

--- a/plugins/anchor-links/index.test.js
+++ b/plugins/anchor-links/index.test.js
@@ -15,15 +15,16 @@ describe('anchor-links', () => {
         ].join('')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
     })
 
@@ -41,50 +42,56 @@ describe('anchor-links', () => {
         { headings }
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "heading-1",
-          "slug": "heading-1",
-          "title": "Heading 1",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 2,
-          "permalinkSlug": "heading-2",
-          "slug": "heading-2",
-          "title": "Heading 2",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 3,
-          "permalinkSlug": "heading-3",
-          "slug": "heading-3",
-          "title": "Heading 3",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 4,
-          "permalinkSlug": "heading-4",
-          "slug": "heading-4",
-          "title": "Heading 4",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 5,
-          "permalinkSlug": "heading-5",
-          "slug": "heading-5",
-          "title": "Heading 5",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 6,
-          "permalinkSlug": "heading-6",
-          "slug": "heading-6",
-          "title": "Heading 6",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "heading-1",
+            "slug": "heading-1",
+            "tabbedSectionDepth": 0,
+            "title": "Heading 1",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 2,
+            "permalinkSlug": "heading-2",
+            "slug": "heading-2",
+            "tabbedSectionDepth": 0,
+            "title": "Heading 2",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 3,
+            "permalinkSlug": "heading-3",
+            "slug": "heading-3",
+            "tabbedSectionDepth": 0,
+            "title": "Heading 3",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 4,
+            "permalinkSlug": "heading-4",
+            "slug": "heading-4",
+            "tabbedSectionDepth": 0,
+            "title": "Heading 4",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 5,
+            "permalinkSlug": "heading-5",
+            "slug": "heading-5",
+            "tabbedSectionDepth": 0,
+            "title": "Heading 5",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 6,
+            "permalinkSlug": "heading-6",
+            "slug": "heading-6",
+            "tabbedSectionDepth": 0,
+            "title": "Heading 6",
+          },
+        ]
       `)
     })
 
@@ -93,7 +100,7 @@ describe('anchor-links', () => {
       expect(headings).toMatchInlineSnapshot(`Array []`)
     })
 
-    test.only('ignores headings in <Tabs/>', () => {
+    test('ignores headings in <Tabs/>', () => {
       const headings = []
       const lines = `# Root Heading
 
@@ -120,42 +127,58 @@ Second tab also has content
 ## Heading After Tabs
 
 Words written after the tabbed section, not within it.
+
+<Tabs></Tabs><Tabs></Tabs>
+
+## Another Heading After Tabs
+
+The multiple Tabs tags in one HTML node above should be handled correctly.
       `.split('\n')
       execute(lines, { headings })
-      expect(headings).toMatchInlineSnapshot(`Array [
-Object {
-  "aliases": Array [],
-  "level": 1,
-  "permalinkSlug": "root-heading",
-  "slug": "root-heading",
-  "tabbedSectionDepth": 0,
-  "title": "Root Heading",
-},
-Object {
-  "aliases": Array [],
-  "level": 2,
-  "permalinkSlug": "first-tab-heading",
-  "slug": "first-tab-heading",
-  "tabbedSectionDepth": 1,
-  "title": "First Tab Heading",
-},
-Object {
-  "aliases": Array [],
-  "level": 2,
-  "permalinkSlug": "second-tab-heading",
-  "slug": "second-tab-heading",
-  "tabbedSectionDepth": 1,
-  "title": "Second Tab Heading",
-},
-Object {
-  "aliases": Array [],
-  "level": 2,
-  "permalinkSlug": "heading-after-tabs",
-  "slug": "heading-after-tabs",
-  "tabbedSectionDepth": 0,
-  "title": "Heading After Tabs",
-},
-]`)
+      expect(headings).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "root-heading",
+            "slug": "root-heading",
+            "tabbedSectionDepth": 0,
+            "title": "Root Heading",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 2,
+            "permalinkSlug": "first-tab-heading",
+            "slug": "first-tab-heading",
+            "tabbedSectionDepth": 1,
+            "title": "First Tab Heading",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 2,
+            "permalinkSlug": "second-tab-heading",
+            "slug": "second-tab-heading",
+            "tabbedSectionDepth": 1,
+            "title": "Second Tab Heading",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 2,
+            "permalinkSlug": "heading-after-tabs",
+            "slug": "heading-after-tabs",
+            "tabbedSectionDepth": 0,
+            "title": "Heading After Tabs",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 2,
+            "permalinkSlug": "another-heading-after-tabs",
+            "slug": "another-heading-after-tabs",
+            "tabbedSectionDepth": 0,
+            "title": "Another Heading After Tabs",
+          },
+        ]
+      `)
     })
 
     test('duplicate slugs', () => {
@@ -184,43 +207,48 @@ Object {
         ].join('\n')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world-1",
-          "slug": "hello-world-1",
-          "title": "hello world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "foo",
-          "title": "foo",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world-2",
-          "slug": "hello-world-2",
-          "title": "hello world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "foo-1",
-          "slug": "foo-1",
-          "title": "foo",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world-1",
+            "slug": "hello-world-1",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "foo",
+            "tabbedSectionDepth": 0,
+            "title": "foo",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world-2",
+            "slug": "hello-world-2",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "foo-1",
+            "slug": "foo-1",
+            "tabbedSectionDepth": 0,
+            "title": "foo",
+          },
+        ]
       `)
     })
 
@@ -249,22 +277,24 @@ Object {
         ].join('\n')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world-1",
-          "slug": "hello-world-1",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world-1",
+            "slug": "hello-world-1",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
     })
 
@@ -287,22 +317,24 @@ Object {
         ].join('\n')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world",
-          "slug": "hello-world",
-          "title": "- hello world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world-1",
-          "slug": "hello-world-1",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "- hello world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world-1",
+            "slug": "hello-world-1",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
     })
 
@@ -333,29 +365,32 @@ Object {
         ].join('\n')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world",
-          "slug": "hello-world",
-          "title": "hEllO----world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world-1",
-          "slug": "hello-world-1",
-          "title": "hello :&-- world",
-        },
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world-foo",
-          "slug": "hello-world-foo",
-          "title": "hello world (foo)()",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hEllO----world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world-1",
+            "slug": "hello-world-1",
+            "tabbedSectionDepth": 0,
+            "title": "hello :&-- world",
+          },
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world-foo",
+            "slug": "hello-world-foo",
+            "tabbedSectionDepth": 0,
+            "title": "hello world (foo)()",
+          },
+        ]
       `)
     })
 
@@ -371,15 +406,16 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
     })
 
@@ -397,15 +433,16 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "hello-world",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "hello-world",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
     })
 
@@ -419,17 +456,18 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [
-            "foo",
-          ],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [
+              "foo",
+            ],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
 
       headings = []
@@ -441,17 +479,18 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [
-            "_foo",
-          ],
-          "level": 1,
-          "permalinkSlug": "_foo",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [
+              "_foo",
+            ],
+            "level": 1,
+            "permalinkSlug": "_foo",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
 
       headings = []
@@ -463,18 +502,19 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [
-            "foo",
-            "bar",
-          ],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [
+              "foo",
+              "bar",
+            ],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "hello-world",
+            "tabbedSectionDepth": 0,
+            "title": "hello world",
+          },
+        ]
       `)
 
       // this *shouldn't* work but currently does, so it has coverage
@@ -487,17 +527,18 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [
-            "foo",
-          ],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "hello-world-more-text",
-          "title": "hello world more text",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [
+              "foo",
+            ],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "hello-world-more-text",
+            "tabbedSectionDepth": 0,
+            "title": "hello world more text",
+          },
+        ]
       `)
     })
 
@@ -511,18 +552,18 @@ Object {
         })
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [
-            "_foo",
-          ],
-          "level": 1,
-          "permalinkSlug": "_foo",
-          "slug": "hello-world",
-          "title": "hello world",
-        },
-      ]
-      `)
+              Array [
+                Object {
+                  "aliases": Array [
+                    "_foo",
+                  ],
+                  "level": 1,
+                  "permalinkSlug": "_foo",
+                  "slug": "hello-world",
+                  "title": "hello world",
+                },
+              ]
+            `)
     })
 
     test('returns only text content', () => {
@@ -668,15 +709,16 @@ Object {
         ].join('\n')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "foo",
-          "title": "foo",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "foo",
+            "tabbedSectionDepth": 0,
+            "title": "foo",
+          },
+        ]
       `)
     })
 
@@ -699,15 +741,16 @@ Object {
         ].join('\n')
       )
       expect(headings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "aliases": Array [],
-          "level": 1,
-          "permalinkSlug": "foo",
-          "slug": "foo",
-          "title": "foo",
-        },
-      ]
+        Array [
+          Object {
+            "aliases": Array [],
+            "level": 1,
+            "permalinkSlug": "foo",
+            "slug": "foo",
+            "tabbedSectionDepth": 0,
+            "title": "foo",
+          },
+        ]
       `)
     })
 


### PR DESCRIPTION
🎟️ [Asana task][task]

For `anchor-links` plugin, this PR adds a `tabbedSectionDepth` property to all heading objects pushed to the `headings` array.

This change is intended to allow consumers of the plugin, such as `dev-portal`, to use `headings` in particular ways based on nesting within `<Tabs />`. Specifically, in `dev-portal`, we do not want to show `headings` that are nested in `<Tabs />` in our table of contents. This change will help facilitate that.

[task]: https://app.asana.com/0/1202097197789424/1202518894520801/f